### PR TITLE
Add CNAME file to repo

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+guide.cloudnativegeo.org

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -84,3 +84,6 @@ format:
 filters:
   - include-files.lua
   - quarto
+
+resources:
+  - CNAME

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,6 +1,5 @@
 project:
   type: website
-  output-dir: docs
   preview:
     port: 4200
     browser: false


### PR DESCRIPTION
### Change list

- Add a `CNAME` file pointing to `guide.cloudnativegeo.org`
- Include the `CNAME` file in the output build
- Restore `_site` as the output directory instead of `docs`, this makes the PR Preview Action bot work again.


Closes https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/issues/60 ref https://github.com/quarto-dev/quarto-cli/discussions/3249