### PR TITLE
Fix past references to DevSeed repo, and guide url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ See the site [https://guide.cloudnativegeo.org/](https://guide.cloudnativegeo.or
 
 **Guide**: <a href="https://tinyurl.com/cogeo-guide" target="_blank">tinyurl.com/cogeo-guide</a>
 
-**Source Code**: <a href="https://github.com/developmentseed/cloud-optimized-geospatial-formats-guide" target="_blank">https://github.com/developmentseed/cloud-optimized-geospatial-formats-guide</a>
+**Source Code**: <a href="https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide" target="_blank">https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide</a>
 
 ---
 
@@ -12,12 +12,12 @@ See the site [https://guide.cloudnativegeo.org/](https://guide.cloudnativegeo.or
 
 This guide aims to provide comprehensive documentation on cloud-optimized geospatial formats. Geospatial data is growing in volume and complexity, and this guide serves to highlight best practices for handling such data, especially in a cloud environment.
 
-For more details, visit the official site: [Cloud-Optimized Geospatial Formats Guide](https://developmentseed.org/cloud-optimized-geospatial-formats-guide/).
+For more details, visit the official site: [Cloud-Optimized Geospatial Formats Guide](https://guide.cloudnativegeo.org/).
 
 ## How to Get Involved
 
 1. Read the [Get Involved](./contributing.qmd) guide for detailed contribution guidelines.
-2. For questions or discussions, start a [GitHub Discussion](https://github.com/developmentseed/cloud-optimized-geospatial-formats-guide/discussions/new/choose).
+2. For questions or discussions, start a [GitHub Discussion](https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/discussions/new/choose).
 
 ## Installation and Local Preview
 
@@ -39,4 +39,4 @@ Preferred citation: `Barciauskas, A et al. 2023. Cloud Optimized Geospatial Form
 
 ## Questions?
 
-If you have any questions or ideas for this guide, please start a [GitHub Discussion](https://github.com/developmentseed/cloud-optimized-geospatial-formats-guide/discussions/new/choose).
+If you have any questions or ideas for this guide, please start a [GitHub Discussion](https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/discussions/new/choose).

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -13,7 +13,7 @@ website:
 
   page-footer:
     right: "This page is built with ❤️ and [Quarto](https://quarto.org/)."
-    left: "&copy; CC-By [Development Seed](https://developmentseed.org), 2023"
+    left: "&copy; CC-By [Cloud-Native Geospatial Foundation](https://cloudnativegeo.org/), 2023"
 
   sidebar:
     pinned: true

--- a/contributing.qmd
+++ b/contributing.qmd
@@ -12,7 +12,7 @@ If you wish to preview the site locally, install [quarto](https://quarto.org/). 
 
 ## Communication Channels
 
-Discussions can occur in [GitHub Discussions](https://github.com/developmentseed/cloud-optimized-geospatial-formats-guide/discussions) and issues can be raised at [GitHub Issues](https://github.com/developmentseed/cloud-optimized-geospatial-formats-guide/issues).
+Discussions can occur in [GitHub Discussions](https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/discussions) and issues can be raised at [GitHub Issues](https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/issues).
 
 
 - **GitHub Discussions**: Ideal for questions, feature requests, or general conversations about the project. Use this space for collaborative discussions or if you're unsure where to start.
@@ -38,7 +38,7 @@ Discussions can occur in [GitHub Discussions](https://github.com/developmentseed
 
 ## Bug Reporting & Feature Requests
 
-Before submitting a bug report or a feature request, please start a [GitHub Discussion](https://github.com/developmentseed/cloud-optimized-geospatial-formats-guide/discussions) to see if the issue has already been addressed or if it can be resolved through discussion.
+Before submitting a bug report or a feature request, please start a [GitHub Discussion](https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/discussions) to see if the issue has already been addressed or if it can be resolved through discussion.
 
 ### General Steps
 
@@ -48,7 +48,7 @@ Before submitting a bug report or a feature request, please start a [GitHub Disc
 4. Make your changes and use `quarto preview` to make sure they look good.
 5. Open a pull request.
 
-Once the pull request is opened, and the GitHub `preview.yml` workflow runs ("Deploy PR previews"), you should have a preview available for review at `https://developmentseed.org/cloud-optimized-geospatial-formats-guide/pr-preview/pr-<YOUR-PR-NUMBER-HERE>`. A bot will comment on your PR when the PR preview is ready.
+Once the pull request is opened, and the GitHub `preview.yml` workflow runs ("Deploy PR previews"), you should have a preview available for review at `https://guide.cloudnativegeo.org/pr-preview/pr-<YOUR-PR-NUMBER-HERE>`. A bot will comment on your PR when the PR preview is ready.
 
 ### Specific Contributions
 
@@ -87,6 +87,6 @@ Preferred citation: `Barciauskas, A et al. 2023. Cloud Optimized Geospatial Form
 
 ## Contact
 
-For questions on how to contribute, start a discussion in the [GitHub Discussions](https://github.com/developmentseed/cloud-optimized-geospatial-formats-guide/discussions) section.
+For questions on how to contribute, start a discussion in the [GitHub Discussions](https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/discussions) section.
 
 {{< include _thankyous.qmd >}}


### PR DESCRIPTION
## What I Changed

Updated website URLs in README and `contributing.qmd` to point to cloudnativegeo instead of DevSeed.

Updated CC to Cloud-Native Geospatial Foundation.

Fixes #71 

## How I tested it

I ran the quarto preview and followed the updated links. 