### PR TITLE
Tweaks on point clouds

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -54,10 +54,8 @@ The diagram below depicts how some of the cloud-optimized formats discussed in t
 Notes:
 
 - Some data formats cover multiple data types, specifically:
-    - GeoJSON can be used for vector and point cloud data.
     - HDF5 can be used for point cloud data or data cubes (or both via groups).
-    - GeoParquet and FlatGeobuf can be used for vector data or point cloud data.
-- LAS files are intended for 3D points, not 2D points (since COPC files are compressed LAS files, the same goes for COPC files).
+- LAS files are intended for Point Clouds (3d points), not 2D points (since COPC files are compressed LAS files, the same goes for COPC files).
 - [TopoJSON](https://github.com/topojson/topojson) (an extension of GeoJSON that encodes topology) and [newline-delimited GeoJSON](https://stevage.github.io/ndgeojson/) are types of GeoJSON worth mentioning but have yet to be explicitly represented in the diagram.
 - GeoTIFF and GeoParquet are geospatial versions of the non-geospatial file formats TIFF and Parquet, respectively. FlatGeobuf builds upon the non-geospatial [flatbuffers](https://github.com/google/flatbuffers) serialization library (though flatbuffers is not a standalone file format)
 


### PR DESCRIPTION
Hey, maybe my understanding of point clouds is off, but this doc seems to talk about them as if they're points. As far as I know you wouldn't put point clouds in GeoJSON, or in geoparquet or flatgeobuf. Las and COPC are the format for point clouds (which are 3d points - https://en.wikipedia.org/wiki/Point_cloud 'A point cloud is a [discrete set](https://en.wikipedia.org/wiki/Discrete_set) of data [points](https://en.wikipedia.org/wiki/Point_(geometry)) in [space](https://en.wikipedia.org/wiki/Space). The points may represent a [3D shape](https://en.wikipedia.org/wiki/3D_shape) or object. Each point [position](https://en.wikipedia.org/wiki/Position_(geometry)) has its set of [Cartesian coordinates](https://en.wikipedia.org/wiki/Cartesian_coordinates) (X, Y, Z)'

I think ideally the diagram would be tweaked too, to say 'point cloud' and maybe show things in 3d. In my view 'vector' is points, lines or polygons, so could maybe represent all 3. 

Thanks for the work on this, other than that it looks great.