### PR TITLE
Add restriction to only run for PRs with main as the target.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,25 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Fail if target is not staging (for PRs only)
+        if: github.event_name == 'pull_request'
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" != "main" || "${{ github.event.pull_request.head.ref }}" == "staging" ]]; then
+            echo "Target branch is acceptable."
+          else
+            echo "Only PRs from staging can target main."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
           python-version: 3.11
 
-      - name: run pre-commit
+      - name: Run pre-commit
         run: |
           python -m pip install pre-commit
           pre-commit run --all-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if target is not staging (for PRs only)
-        if: github.event_name == 'pull_request'
-        run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" != "main" || "${{ github.event.pull_request.head.ref }}" == "staging" ]]; then
-            echo "Target branch is acceptable."
-          else
-            echo "Only PRs from staging can target main."
-            exit 1
-          fi
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,19 @@ on:
   pull_request:
 
 jobs:
+  pr-target-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if target is not staging (for PRs only)
+        if: github.event_name == 'pull_request'
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" != "main" || "${{ github.event.pull_request.head.ref }}" == "staging" ]]; then
+            echo "Target branch is acceptable."
+          else
+            echo "Only PRs from staging can target main."
+            exit 1
+          fi
+          
   tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,6 +2,8 @@ name: Deploy PR previews
 
 on:
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - reopened


### PR DESCRIPTION
## What I Changed

For background information: See #74.

The preview action on external forks has failed because the [pr-preview-action](https://github.com/rossjrw/pr-preview-action) does not support preview on external forks. Also, [it intends to refrain from supporting in the future](https://github.com/rossjrw/pr-preview-action/pull/6#issuecomment-1523392380).

The PR changes the preview action to only run on PRs to main.

## How I tested it

For the changes to `ci.yml`:

`pr-test-success.json`
```
{
  "pull_request": {
    "head": {
      "ref": "staging"
    },
    "base": {
      "ref": "main"
    }
  }
}
```
`pr-test-fail.json`
```
{
  "pull_request": {
    "head": {
      "ref": "random"
    },
    "base": {
      "ref": "main"
    }
  }
}
```

Run the workflows of the added job with:
```bash
act pull_request -W .github/workflows/ci.yml -e p.json -j pr-test-success
act pull_request -W .github/workflows/ci.yml -e p.json -j pr-test-fail
```



