### PR TITLE
Update Zarr visualization link

### DIFF
--- a/cookbooks/index.qmd
+++ b/cookbooks/index.qmd
@@ -10,4 +10,4 @@ Cookbooks should address common questions and present solutions for cloud-optimi
 
 Cookbooks:
 
-* [Zarr Visualization Cookbook (in development)](https://nasa-impact.github.io/zarr-visualization-cookbook/)
+* [Zarr Visualization Report (in development)](https://nasa-impact.github.io/zarr-visualization-report/)


### PR DESCRIPTION
It looks like https://nasa-impact.github.io/zarr-visualization-cookbook/ (currently gives a 404) has been renamed to https://nasa-impact.github.io/zarr-visualization-report/