### PR TITLE
Update Table of Contents

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -68,9 +68,11 @@ Notes:
    a. [Cloud-Optimized GeoTIFFs](./cloud-optimized-geotiffs/intro.qmd)
    b. [Zarr](./zarr/intro.qmd)
    c. [Kerchunk](./kerchunk/intro.qmd)
-   c. [Cloud-Optimized NetCDF4/HDF5](./cloud-optimized-netcdf4-hdf5/index.qmd)
-   d. [GeoParquet](./geoparquet/index.qmd)
-   e. [FlatGeobuf](./flatgeobuf/intro.qmd)
+   d. [Cloud-Optimized NetCDF4/HDF5](./cloud-optimized-netcdf4-hdf5/index.qmd)
+   e. [Cloud-Optimized Point Clouds (COPS)](./copc/index.qmd)
+   f. [GeoParquet](./geoparquet/index.qmd)
+   g. [FlatGeobuf](./flatgeobuf/intro.qmd)
+   h. [PMTiles](./pmtiles/intro.qmd)
 3. [Cookbooks](./cookbooks/index.qmd)
 
 


### PR DESCRIPTION
# Pull Request

Currently the formats of `Cloud-Optimized Point Clouds (COPS)` and `PMTiles` are not included in the main overview listing. To ensure it is aligned with the navigation menu they are now added with this pull request (+ the duplicate `c` enumeration identifier gets resolved).