### PR TITLE
Update index.qmd

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -69,7 +69,7 @@ Notes:
    b. [Zarr](./zarr/intro.qmd)
    c. [Kerchunk](./kerchunk/intro.qmd)
    d. [Cloud-Optimized NetCDF4/HDF5](./cloud-optimized-netcdf4-hdf5/index.qmd)
-   e. [Cloud-Optimized Point Clouds (COPS)](./copc/index.qmd)
+   e. [Cloud-Optimized Point Clouds (COPC)](./copc/index.qmd)
    f. [GeoParquet](./geoparquet/index.qmd)
    g. [FlatGeobuf](./flatgeobuf/intro.qmd)
    h. [PMTiles](./pmtiles/intro.qmd)


### PR DESCRIPTION
Fix typo. COPS -> COPC.

Originally submitted by @hfu in https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/pull/113. 