### PR TITLE
remove note on bbox not being available in read_info

### DIFF
--- a/flatgeobuf/flatgeobuf.ipynb
+++ b/flatgeobuf/flatgeobuf.ipynb
@@ -298,12 +298,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "::: {.callout-note}\n",
-    "\n",
-    "Sadly the output of `read_info` does [not yet include](https://github.com/geopandas/pyogrio/issues/274) the bounding box of the file, even though the FlatGeobuf file contains that information in the header. This may be a reason to consider externalizing metadata using [Spatio-Temporal Asset Catalog files](https://stacspec.org/en) (STAC) in the future.\n",
-    "\n",
-    ":::\n",
-    "\n",
     "For now we'll hard-code a region around Valence in the south of France, which we know the be within our dataset."
    ]
   },


### PR DESCRIPTION
Because now it is.

Closes #147 