### PR TITLE
Update Contributing Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For more details, visit the official site: [Cloud-Optimized Geospatial Formats G
 
 ## How to Get Involved
 
-1. Read the [Get Involved](./contributing.qmd) guide for detailed contribution guidelines.
+1. Read the [Get Involved](https://guide.cloudnativegeo.org/contributing.html) guide for detailed contribution guidelines.
 2. For questions or discussions, start a [GitHub Discussion](https://github.com/cloudnativegeo/cloud-optimized-geospatial-formats-guide/discussions/new/choose).
 
 ## Installation and Local Preview

--- a/contributing.qmd
+++ b/contributing.qmd
@@ -48,7 +48,7 @@ Before submitting a bug report or a feature request, please start a [GitHub Disc
 4. Make your changes and use `quarto preview` to make sure they look good.
 5. Open a pull request.
 
-Once the pull request is opened, and the GitHub `preview.yml` workflow runs ("Deploy PR previews"), you should have a preview available for review at `https://guide.cloudnativegeo.org/pr-preview/pr-<YOUR-PR-NUMBER-HERE>`. A bot will comment on your PR when the PR preview is ready.
+Once your pull request is opened, Netlify will automatically build a preview of your changes. A bot will comment with a link once the preview is ready.
 
 ### Specific Contributions
 


### PR DESCRIPTION
### What I changed
- Removed the outdated reference to the preview.yml GitHub Actions workflow from contributing.qmd.
- Updated the instructions to reflect that PR previews are now handled via Netlify, with a bot posting the preview link automatically.

### How to test it
- Run quarto preview locally or check the Netlify deploy preview.
- Navigate to the "Get Involved" page.
- Confirm that:
    - There is no mention of preview.yml or GitHub Actions.
    - The instructions clearly explain that previews are generated by Netlify and a bot comments with the link.

### Other notes

- This change aligns the contribution documentation with the deployment updates in Publish previews using netlify #166
- Closes Clean Up Contribution docs #168